### PR TITLE
WIP: Use new parser API

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,7 +4,9 @@ version = "0.2.0"
 
 [deps]
 CSTParser = "00ebfdb7-1f24-5e51-bd34-a7502290713f"
+Tokenize = "0796e94c-ce3b-5d07-9a54-7f471281c624"
 
 [compat]
+CSTParser = "2.2"
+Tokenize = "0.5"
 julia = "1"
-CSTParser = "2"

--- a/Project.toml
+++ b/Project.toml
@@ -1,0 +1,10 @@
+name = "FancyDiagnostics"
+uuid = "29b9fc01-2d52-5901-8357-88823a8aad60"
+version = "0.2.0"
+
+[deps]
+CSTParser = "00ebfdb7-1f24-5e51-bd34-a7502290713f"
+
+[compat]
+julia = "1"
+CSTParser = "2"

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,2 +1,0 @@
-julia 0.6
-CSTParser

--- a/src/FancyDiagnostics.jl
+++ b/src/FancyDiagnostics.jl
@@ -1,7 +1,9 @@
 module FancyDiagnostics
 
 using CSTParser
-using CSTParser: typof, EXPR
+using CSTParser: typof, EXPR, kindof, errorof
+
+using Tokenize
 
 include("LineNumbers.jl")
 include("display.jl")

--- a/src/FancyDiagnostics.jl
+++ b/src/FancyDiagnostics.jl
@@ -1,5 +1,7 @@
 module FancyDiagnostics
-    include("LineNumbers.jl")
-    include("display.jl")
-    include("hooks.jl")
+
+include("LineNumbers.jl")
+include("display.jl")
+include("hooks.jl")
+
 end # module

--- a/src/FancyDiagnostics.jl
+++ b/src/FancyDiagnostics.jl
@@ -1,5 +1,8 @@
 module FancyDiagnostics
 
+using CSTParser
+using CSTParser: typof, EXPR
+
 include("LineNumbers.jl")
 include("display.jl")
 include("hooks.jl")

--- a/src/LineNumbers.jl
+++ b/src/LineNumbers.jl
@@ -1,47 +1,80 @@
-struct SourceFile
+"""
+    SourceText(code; filename="none")
+
+A source file
+"""
+struct SourceText # TODO: Make this be a 0-based AbstractString?
     data::Vector{UInt8}
     filename::String
 end
 
-SourceFile(code::Vector{UInt8}, filename) = SourceFile(code, filename)
-SourceFile(code::AbstractString, filename) = SourceFile(Vector{UInt8}(String(code)), filename)
+SourceText(code::Vector{UInt8}, filename) = SourceText(code, filename)
+SourceText(code::AbstractString, filename) = SourceText(Vector{UInt8}(String(code)), filename)
 
-SourceFile(;     filename="none") = SourceFile(read(filename), filename)
-SourceFile(code; filename="none") = SourceFile(code, filename)
+SourceText(;     filename="none") = SourceText(read(filename), filename)
+SourceText(code; filename="none") = SourceText(code, filename)
 
-function Base.show(io::IO, file::SourceFile)
-    preview = readline(IOBuffer(file.data), keep=true)
-    print(io, "SourceFile($(repr(string(preview, "…"))); filename=$(repr(file.filename)))")
+function Base.show(io::IO, file::SourceText)
+    buf = IOBuffer(file.data)
+    println(io, "SourceText(\"\"\"")
+    for i = 1:20
+        print(io, readline(buf, keep=true))
+    end
+    if !eof(buf)
+        println(io, "…")
+    end
+    print(io, "\"\"\"; filename=$(repr(file.filename)))")
 end
 
+Base.getindex(file::SourceText, rng::AbstractUnitRange) = String(file.data[first(rng)+1:last(rng)])
+
 struct IndexedSource <: AbstractVector{String}
-    file::SourceFile
+    file::SourceText
     # offsets contains the (zero-based) byte offset for the character at the
     # start of each line. One additional offset is included past the end of the
     # file.
     offsets::Vector{UInt64}
 end
 
-function IndexedSource(file::SourceFile)
+function IndexedSource(file::SourceText)
     buf = IOBuffer(file.data)
-    offsets = UInt64[0]
-    while true
+    offsets = UInt[0]
+    while !eof(buf)
         line = readuntil(buf, '\n', keep=true)
         push!(offsets, position(buf))
-        if eof(buf)
-            if !endswith(line, '\n')
-                offsets[end] += 1
-            end
-            break
-        end
     end
     IndexedSource(file, offsets)
 end
 
+function line_start_offset(src::IndexedSource, offset, delta_lines=0)
+    if length(src.offsets) == 1
+        return 0
+    end
+    line = searchsortedlast(src.offsets, offset)
+    src.offsets[clamp(line + delta_lines, 1, length(src.offsets))]
+end
+
+function line_end_offset(src::IndexedSource, offset, delta_lines=0)
+    if length(src.offsets) == 1
+        return 0
+    end
+    line = searchsortedlast(src.offsets, offset)
+    off = src.offsets[clamp(line + 1 + delta_lines, 1, length(src.offsets))]
+    if off > 0
+        off -= 1 # remove '\n'
+    end
+    off
+end
+
 function source_location(src::IndexedSource, offset; prevchar=false)
+    if length(src.offsets) == 1
+        # Zero lines
+        return (1,1)
+    end
     line = searchsortedlast(src.offsets, offset)
     if line == length(src.offsets)
-        partial_line = ""
+        line -= 1
+        partial_line = src[line]
     else
         partial_line = String(src.file.data[src.offsets[line]+1:offset+1])
     end
@@ -57,6 +90,10 @@ function source_location(src::IndexedSource, offset; prevchar=false)
     (line,col)
 end
 
+function source_line(src::IndexedSource, offset)
+    first(source_location(src, offset))
+end
+
 function Base.summary(io::IO, src::IndexedSource)
     print(io, "IndexedSource for $(repr(src.file.filename)) with $(length(src)) lines")
 end
@@ -70,48 +107,7 @@ function Base.getindex(src::IndexedSource, line::Int)
         return ""
     end
     i1 = src.offsets[line] + 1    # Offsets are zero-based
-    i2 = src.offsets[line+1] - 1  # NB: skip '\n'
-    return String(src.file.data[i1:i2])
+    i2 = src.offsets[line+1]
+    return rstrip(String(src.file.data[i1:i2]), '\n')
 end
-
-
-#-------------------------------------------------------------------------------
-#=
-"""
-Indexing adaptor to map from a flat byte offset to a `[line][offset]` pair.
-Optionally, off may specify a byte offset relative to which the line number and
-offset should be computed
-"""
-struct LineBreaking{T}
-    off::UInt64
-    file::SourceFile
-    obj::T
-end
-
-function indtransform(lb::LineBreaking, x::Int)
-    offline = compute_line(lb.file, lb.off)
-    line = compute_line(lb.file, x)
-    lineoffset = lb.file.offsets[line]
-    off = x - lineoffset + 1
-    if lineoffset < lb.off
-        off -= lb.off - lineoffset
-    end
-    (line - offline + 1), off
-end
-
-function Base.getindex(lb::LineBreaking, x::Int)
-    l, o = indtransform(lb, x)
-    lb.obj[l][o]
-end
-
-function Base.setindex!(lb::LineBreaking, y, x::Int)
-    l, o = indtransform(lb, x)
-    lb.obj[l][o] = y
-end
-function Base.setindex!(lb::LineBreaking, y, x::AbstractArray)
-    for i in x
-        lb[i] = y
-    end
-end
-=#
 

--- a/src/display.jl
+++ b/src/display.jl
@@ -1,48 +1,92 @@
-struct REPLDiagnostic
-    fname::AbstractString
-    text::AbstractString
-    diags::Any
+# Find first parser error. All other errors are ignored.
+function first_error(ex::EXPR, pos=0)
+    _first_error(ex, Tuple{EXPR,Int}[], pos)
 end
 
-function Base.showerror(io::IO, d::REPLDiagnostic, bt; backtrace=false)
-    printstyled(io, ""; color=:white)
-    display_diagnostic(io, d.text, d.diags; filename = d.fname)
-end
-Base.display_error(io::IO, d::REPLDiagnostic, bt) = Base.showerror(io, d, bt)
-
-function Base.showerror(io::IO, d::REPLDiagnostic)
-    printstyled(io, ""; color=:white)
-    display_diagnostic(io, d.text, d.diags; filename = d.fname)
-end
-
-function display_diagnostic(io::IO, code, diagnostics; filename = "none")
-    file = SourceFile(code)
-    for (i,message) in enumerate(diagnostics)
-        if isempty(message.loc)
-            i != 1 && (printstyled(io, "ERROR", color=:red, bold=true); print(io, ": "))
-            println(io, message.description)
-            continue
-        end
-        offset = first(message.loc)
-        line = compute_line(file, offset)
-        str  = String(file[line])
-        lineoffset = offset - file.offsets[line]
-        col  = (lineoffset == 0 || isempty(str)) ? 1 :
-               lineoffset > sizeof(str) ? textwidth(str) + 1 :
-                textwidth(str[1:lineoffset])
-        if false #message.severity == :fixit
-            print(io, " "^(col-1))
-            printstyled(io, message.text, color=:green)
-            println(io)
-        else
-            print(io, "$filename:$line:$col " )
-            i != 1 && (printstyled(io, "ERROR", color=:red, bold=true); print(io, ": "))
-            println(io, message.description)
-            println(io, rstrip(str))
-            print(io, " "^(col-1))
-            printstyled(io, string('^',"~"^(max(0,length(message.loc)-1))); color=:green, bold = true)
-            println(io)
-        end
+function _first_error(ex, trace, pos)
+    push!(trace, (ex,pos))
+    if typof(ex) === CSTParser.ErrorToken
+        return trace
     end
+    for i in 1:length(ex)
+        res = _first_error(ex[i], trace, pos)
+        if !isnothing(res)
+            return res
+        end
+        pos += ex[i].fullspan
+    end
+    pop!(trace)
+    return nothing
+end
+
+function make_underline(width,
+                        #chars=('^','~','^','|')
+                        chars=('▔','▔','▔','▎')
+                        #chars=('┗','━','┛','▎')
+                       )
+    if width == 0
+        chars[4]
+    elseif width <= 2
+        chars[2]^width
+    else
+        string(chars[1], chars[2]^(width-2), chars[3])
+    end
+end
+
+function explain_error(ex)
+    # FIXME: Framework for explaining parse errors
+    errcode = CSTParser.errorof(ex)
+    if errcode == CSTParser.UnexpectedToken
+        "Unexpected token"
+    elseif errcode == CSTParser.CannotJuxtapose
+        "Cannot juxtapose"
+    elseif errcode == CSTParser.UnexpectedWhiteSpace
+        "Unexpected white space"
+    elseif errcode == CSTParser.UnexpectedNewLine
+        "Unexpected newline"
+    elseif errcode == CSTParser.ExpectedAssignment
+        "Expected assignment"
+    elseif errcode == CSTParser.UnexpectedAssignmentOp
+        "Unexpected assignment"
+    elseif errcode == CSTParser.MissingConditional
+        "Missing conditional"
+    elseif errcode == CSTParser.MissingCloser
+        "Missing closer"
+    elseif errcode == CSTParser.InvalidIterator
+        "Invalid iterator"
+    elseif errcode == CSTParser.StringInterpolationWithTrailingWhitespace
+        "'\$' cannot be followed by whitespace in string interpolation"
+    elseif errcode == CSTParser.TooLongChar
+        "Character too long"
+    elseif errcode == CSTParser.Unknown
+        "Unknown error!"
+    else
+        "Unknown error code ($errcode)"
+    end
+end
+
+# TODO: line numbers + terminal links in message!!
+
+function display_diagnostic(io, src, ex0, offset0; ctxlines=3)
+    trace = first_error(ex0, offset0)
+    ex,offset = trace[end]
+    indexed = IndexedSource(src)
+    line,col = source_location(indexed, offset)
+    println(io, "Parsing failed at $(src.filename):$line:$col")
+    for ln = max(1,line-ctxlines):max(0,line-1)
+        println(io, rstrip(indexed[ln]))
+    end
+    endline,endcol = source_location(indexed, offset + ex.span, prevchar=true)
+    endcol2 = endline == line ? endcol : textwidth(indexed[line])
+    println(io, rstrip(indexed[line]))
+    print(io, ' '^max(0,col-1))
+    printstyled(io, make_underline(endcol2-col+1); color=:green, bold = true)
+    println(io)
+    printstyled(io, string(explain_error(ex), "\n"); color=:red)
+    println(io)
+    # DEBUG: Dump node
+    #e2 = deepcopy(ex)
+    #e2.parent=nothing
+    #dump(e2)
 end
 

--- a/src/display.jl
+++ b/src/display.jl
@@ -1,8 +1,21 @@
-using .LineNumbers: SourceFile, compute_line
-using CSTParser
-using CSTParser: Error
+struct REPLDiagnostic
+    fname::AbstractString
+    text::AbstractString
+    diags::Any
+end
 
-function display_diagnostic(io::IO, code, diagnostics::Vector{Error}; filename = "none")
+function Base.showerror(io::IO, d::REPLDiagnostic, bt; backtrace=false)
+    printstyled(io, ""; color=:white)
+    display_diagnostic(io, d.text, d.diags; filename = d.fname)
+end
+Base.display_error(io::IO, d::REPLDiagnostic, bt) = Base.showerror(io, d, bt)
+
+function Base.showerror(io::IO, d::REPLDiagnostic)
+    printstyled(io, ""; color=:white)
+    display_diagnostic(io, d.text, d.diags; filename = d.fname)
+end
+
+function display_diagnostic(io::IO, code, diagnostics; filename = "none")
     file = SourceFile(code)
     for (i,message) in enumerate(diagnostics)
         if isempty(message.loc)
@@ -32,3 +45,4 @@ function display_diagnostic(io::IO, code, diagnostics::Vector{Error}; filename =
         end
     end
 end
+

--- a/src/hooks.jl
+++ b/src/hooks.jl
@@ -1,35 +1,32 @@
 struct CSTParseError <: Exception
     cst::EXPR
     src::SourceText
-    offset::UInt64
+    index::UInt64
 end
 
 function display_diagnostic(io, err::CSTParseError)
-    display_diagnostic(io, err.src, err.cst, err.offset)
+    display_diagnostic(io, err.src, err.cst, err.index)
 end
 
 function Base.showerror(io::IO, err::CSTParseError, bt; backtrace=false)
-    #printstyled(io, ""; color=:white) # TODO?
     display_diagnostic(io, err)
 end
 Base.display_error(io::IO, err::CSTParseError, bt) = Base.showerror(io, err, bt)
 
 function Base.showerror(io::IO, err::CSTParseError)
-    #printstyled(io, ""; color=:white) # TODO?
     display_diagnostic(io, err)
 end
 
 function to_Expr(cst, src, offset)
     if CSTParser.has_error(cst)
         # Remove cst.parent ?
-        Expr(:error, CSTParseError(cst, src, offset))
+        Expr(:error, CSTParseError(cst, src, offset+1))
     else
-        Expr(cst)
+        CSTParser.to_Expr(CSTParser.EXPRIndexer(cst, String(copy(src.data)), src.filename))
     end
 end
 
-function cst_parse(src::SourceText, offset; rule::Symbol=:statement, options...)
-    # Options other than `rule` ignored for now...
+function cst_parse(src::SourceText, offset; rule::Symbol=:statement)
     if rule ∉ (:atom,:statement,:all)
         error("Unknown parser rule: $rule")
     end
@@ -82,74 +79,12 @@ function julia_parse(text, filename, offset, options)
     return Core.Compiler.fl_parse(text, filename, offset, options)
 end
 
-function init!()
-    Core.Compiler.set_parser(julia_parse)
+function enable!()
+    Core.eval(Core, :(_parse = $julia_parse))
+    nothing
 end
 
-function panic!()
-    Core.Compiler.set_parser(Core.Compiler.fl_parse)
+function disable!()
+    Core.eval(Core, :(_parse = Core.Compiler.fl_parse))
+    nothing
 end
-
-#=
-function _include_string(m::Module, fname, text)
-    ps = CSTParser.ParseState(text)
-    local result = nothing
-    while !ps.done && isempty(ps.errors)
-        result, ps = Parser.parse(ps)
-        if !isempty(ps.errors)
-            throw(REPLDiagnostic(fname, text, ps.errors))
-        end
-        result = ccall(:jl_toplevel_eval, Any, (Any, Any), m, Expr(result))
-    end
-    result
-end
-
-function Core.include(m::Module, fname::String)
-    text = open(readstring, fname)
-    _include_string(fname, text)
-end
-Base.include_string(m::Module, txt::String, fname::String) = _include_string(filename, code)
-
-function is_incomplete(diag)
-    return false
-end
-
-function Base.Meta.parse(str::AbstractString, pos::Int; greedy::Bool=true, raise::Bool=true, depwarn::Bool=true)
-    # Non-greedy mode not yet supported
-    @assert greedy
-    io = IOBuffer(str)
-    seek(io, pos-1)
-    ps = CSTParser.ParseState(io)
-    result, ps = CSTParser.parse(ps)
-    if !isempty(ps.errors)
-        diag = REPLDiagnostic("REPL", str, ps.errors)
-        raise && throw(diag)
-        return is_incomplete(diag) ? Expr(:incomplete, diag) : Expr(:error, diag), pos + result.fullspan
-    end
-    Expr(result), pos + result.fullspan
-end
-
-function Base.incomplete_tag(ex::Expr)
-    Meta.isexpr(ex, :incomplete) || return :none
-    (length(ex.args) != 1 || !isa(ex.args[1], REPLDiagnostic)) && return :other
-    ex.args[1].error_code == Diagnostics.UnexpectedStringEnd && return :string
-    ex.args[1].error_code == Diagnostics.UnexpectedCommentEnd && return :comment
-    ex.args[1].error_code == Diagnostics.UnexpectedBlockEnd && return :block
-    ex.args[1].error_code == Diagnostics.UnexpectedCmdEnd && return :cmd
-    ex.args[1].error_code == Diagnostics.UnexpectedCharEnd && return :char
-    return :other
-end
-
-function Base.parse_input_line(code::String; filename::String="none", depwarn=true)
-    ps = CSTParser.ParseState(code)
-    result, ps = CSTParser.parse(ps)
-    if !isempty(ps.errors)
-        diag = REPLDiagnostic(filename, code, ps.errors)
-        return is_incomplete(diag) ? Expr(:incomplete, diag) : Expr(:error, diag)
-    end
-    result == nothing && return result
-    Expr(result)
-end
-
-=#
-

--- a/src/hooks.jl
+++ b/src/hooks.jl
@@ -1,180 +1,121 @@
-using CSTParser
-using CSTParser: typof, EXPR
-
-# Find first parser error. All other errors are ignored.
-function first_error(ex::EXPR)
-    _first_error(ex, Tuple{EXPR,Int}[], 0)
+struct CSTParseError <: Exception
+    cst::EXPR
+    src::SourceFile
+    offset::UInt64
 end
 
-function _first_error(ex, trace, pos)
-    push!(trace, (ex,pos))
-    if typof(ex) === CSTParser.ErrorToken
-        return trace
-    end
-    for i in 1:length(ex)
-        res = _first_error(ex[i], trace, pos)
-        if !isnothing(res)
-            return res
-        end
-        pos += ex[i].fullspan
-    end
-    pop!(trace)
-    return nothing
+function display_diagnostic(io, err::CSTParseError)
+    display_diagnostic(io, err.src, err.cst, err.offset)
 end
 
-function cst_parse(src::SourceFile, rule)
-    buf = IOBuffer(src.data)
-    ps = CSTParser.ParseState(buf)
-    cont = rule == 2 ? false : true
-    cst,_ = CSTParser.parse(ps, cont)
-    err_trace = first_error(cst)
-    if !isnothing(err_trace)
-        report_error(stderr, src, err_trace)
-    end
-    cst
+function Base.showerror(io::IO, err::CSTParseError, bt; backtrace=false)
+    #printstyled(io, ""; color=:white) # TODO?
+    display_diagnostic(io, err)
+end
+Base.display_error(io::IO, err::CSTParseError, bt) = Base.showerror(io, err, bt)
+
+function Base.showerror(io::IO, err::CSTParseError)
+    #printstyled(io, ""; color=:white) # TODO?
+    display_diagnostic(io, err)
 end
 
-function make_underline(width,
-                        #chars=('^','~','^','|')
-                        chars=('▔','▔','▔','▎')
-                        #chars=('┗','━','┛','▎')
-                       )
-    if width == 0
-        chars[4]
-    elseif width <= 2
-        chars[2]^width
+# Determine whether an ErrorToken occurs in EXPR.
+#
+# NB: ParseState `errored` can be false while `has_error` is true. Maybe
+# `errored` is set only when the parser hits an error it considers locally
+# "non-recoverable" ???
+function has_error(cst::EXPR)
+    if typof(cst) == CSTParser.ErrorToken
+        return true
+    elseif isnothing(cst.args)
+        return false
     else
-        string(chars[1], chars[2]^(width-2), chars[3])
+        return any(has_error, cst.args)
     end
 end
 
-function explain_error(err_trace)
-    ex,_ = err_trace[end]
-    # FIXME: Framework for explaining parse errors
-    errcode = CSTParser.errorof(ex)
-    if errcode == CSTParser.UnexpectedToken
-        "Unexpected token"
-    elseif errcode == CSTParser.CannotJuxtapose
-        "Cannot juxtapose"
-    elseif errcode == CSTParser.UnexpectedWhiteSpace
-        "Unexpected white space"
-    elseif errcode == CSTParser.UnexpectedNewLine
-        "Unexpected newline"
-    elseif errcode == CSTParser.ExpectedAssignment
-        "Expected assignment"
-    elseif errcode == CSTParser.UnexpectedAssignmentOp
-        "Unexpected assignment"
-    elseif errcode == CSTParser.MissingConditional
-        "Missing conditional"
-    elseif errcode == CSTParser.MissingCloser
-        "Missing closer"
-    elseif errcode == CSTParser.InvalidIterator
-        "Invalid iterator"
-    elseif errcode == CSTParser.StringInterpolationWithTrailingWhitespace
-        "'\$' cannot be followed by whitespace in string interpolation"
-    elseif errcode == CSTParser.TooLongChar
-        "Character too long"
-    elseif errcode == CSTParser.Unknown
-        "Unknown error!"
+function to_Expr(cst, src, offset)
+    if has_error(cst)
+        # Remove cst.parent ?
+        Expr(:error, CSTParseError(cst, src, offset))
     else
-        "Unknown error code ($errcode)"
+        Expr(cst)
     end
 end
 
-function report_error(io, src, err_trace; ctxlines=3)
-    indexed = IndexedSource(src)
-    ex,offset = err_trace[end]
-    line,col = source_location(indexed, offset)
-    for ln = max(1,line-ctxlines):max(0,line-1)
-        println(io, rstrip(indexed[ln]))
-    end
-    endline,endcol = source_location(indexed, offset + ex.span)
-    endcol2 = endline == line ? endcol : textwidth(indexed[line])
-    println(io, rstrip(indexed[line]))
-    print(io, ' '^(col-1))
-    printstyled(io, make_underline(endcol2-col+1); color=:green, bold = true)
-    println(io)
-    printstyled(io, "ERROR"; color=:red)
-    println(io, " at $(src.filename):$line:$col")
-    println(io, explain_error(err_trace))
-    println(io)
-    e2 = deepcopy(ex)
-    e2.parent=nothing
-    dump(e2)
-end
-
-# jl_parse implementation using CSTParser
-function julia_jl_parse(text, text_len, filename, filename_len, pos0, rule)
-    if rule == 1
-        error("TODO")
-    elseif rule != 2 && rule != 3
+function cst_parse(src::SourceFile, offset; rule::Symbol=:statement, options...)
+    # Options other than `rule` ignored for now...
+    if rule ∉ (:atom,:statement,:all)
         error("Unknown parser rule: $rule")
     end
-    if pos0 != 0
-        error("TODO")
+    # Parse
+    buf = IOBuffer(src.data)
+    seek(buf, offset)
+    ps = CSTParser.ParseState(buf)
+    cst,ps = CSTParser.parse(ps, rule == :all)
+    # Convert to Expr
+    if has_error(cst)
+        # Ugh: src.data is `unsafe_wrap`d => deepcopy
+        src = deepcopy(src)
     end
-    src = SourceFile(unsafe_wrap(Array, text, text_len),
-                     filename=unsafe_string(filename, filename_len))
-    cst = cst_parse(src, rule)
-    ex = Expr(cst)
-    if ex isa Expr && ex.head == :file
-        ex = Expr(:toplevel, ex.args...)
+    srccopy = nothing
+    if typof(cst) == CSTParser.FileH
+        args = Any[]
+        for a in cst.args
+            push!(args, to_Expr(a, src, offset))
+            offset += a.fullspan
+        end
+        ex = Expr(:toplevel, args...)
+    else
+        ex = to_Expr(cst, src, offset)
+        offset += cst.fullspan
     end
-    return Core.svec(ex, text_len)
+    return ex, offset
+end
+
+function fl_parse(text, text_len, filename, filename_len, offset, rule)
+    @ccall jl_fl_parse(text::Ptr{UInt8}, sizeof(text)::Csize_t,
+                       filename::Ptr{UInt8}, sizeof(filename)::Csize_t,
+                       offset::Csize_t, rule::Any)::Any
 end
 
 # Extra shim for sanity during development
-function _julia_jl_parse(text, text_len, filename, filename_len, pos0, rule)
+function _julia_jl_parse(text, text_len, filename, filename_len, offset, options)
+    # flisp parser uses single rule Symbol as options
+    opts = options isa Symbol ? (rule=options,) : options
     try
-        res = Base.invokelatest(julia_jl_parse, text, text_len,
-                                filename, filename_len, pos0, rule)
-        return res
+        if opts.rule == :atom
+            # TODO!
+            return fl_parse(text, text_len, filename, filename_len, offset, opts.rule)
+        end
+        src = SourceFile(unsafe_wrap(Array, text, text_len),
+                         filename=unsafe_string(filename, filename_len))
+        ex, pos = cst_parse(src, offset; opts...)
+        # Rewrap in an svec for use by the C code
+        return Core.svec(ex, pos)
     catch exc
-        @error "Calling CSTParser failed. Falling back to flisp parser" #=
-        =#     exception=exc,catch_backtrace()
-        return @ccall jl_fl_parse(text::Ptr{UInt8}, sizeof(text)::Csize_t,
-                                  filename::Ptr{UInt8}, sizeof(filename)::Csize_t,
-                                  pos0::Csize_t, rule::Cint)::Any
+        @error("Calling CSTParser failed — disabling!",
+               exception=(exc,catch_backtrace()),
+               offset=offset,
+               code=String(unsafe_wrap(Array, text, text_len))
+        )
+        panic!()
     end
+    return fl_parse(text, text_len, filename, filename_len, offset, opts.rule)
 end
 
-function set_parser!()
-    parser = @cfunction(_julia_jl_parse, Any,
-                        (Ptr{UInt8}, Csize_t, Ptr{UInt8}, Csize_t, Csize_t, Cint))
+function init!()
+    # Debug hack - FIXME don't use @eval here!
+    parser = @eval @cfunction(_julia_jl_parse, Any,
+                              (Ptr{UInt8}, Csize_t, Ptr{UInt8}, Csize_t, Csize_t, Any))
     @ccall jl_set_parser(parser::Ptr{Cvoid})::Cvoid
 end
 
-# Hack: quick test tool
-function test_jl_parse(text, filename, pos, rule)
-    pos0 = pos-1
-    parser = @eval @cfunction(_julia_jl_parse, Any,
-                        (Ptr{UInt8}, Csize_t, Ptr{UInt8}, Csize_t, Csize_t, Cint))
-    @ccall $parser(text::Ptr{UInt8}, sizeof(text)::Csize_t,
-                   filename::Ptr{UInt8}, sizeof(filename)::Csize_t,
-                   pos0::Csize_t, rule::Cint)::Any
+function panic!()
+    @ccall jl_set_parser(cglobal(:jl_fl_parse)::Ptr{Cvoid})::Cvoid
 end
 
 #=
-using FancyDiagnostics: display_diagnostic
-using Base: Meta
-
-struct REPLDiagnostic
-    fname::AbstractString
-    text::AbstractString
-    diags::Any
-end
-
-function Base.showerror(io::IO, d::REPLDiagnostic, bt; backtrace=false)
-    printstyled(io, ""; color=:white)
-    display_diagnostic(io, d.text, d.diags; filename = d.fname)
-end
-Base.display_error(io::IO, d::REPLDiagnostic, bt) = Base.showerror(io, d, bt)
-
-function Base.showerror(io::IO, d::REPLDiagnostic)
-    printstyled(io, ""; color=:white)
-    display_diagnostic(io, d.text, d.diags; filename = d.fname)
-end
-
 function _include_string(m::Module, fname, text)
     ps = CSTParser.ParseState(text)
     local result = nothing
@@ -186,13 +127,6 @@ function _include_string(m::Module, fname, text)
         result = ccall(:jl_toplevel_eval, Any, (Any, Any), m, Expr(result))
     end
     result
-end
-
-# Pirate base definitions
-# mute override warnings
-if ccall(:jl_generating_output, Cint, ()) == 0
-    ORIG_STDERR = STDERR
-    redirect_stderr()
 end
 
 function Core.include(m::Module, fname::String)
@@ -242,9 +176,5 @@ function Base.parse_input_line(code::String; filename::String="none", depwarn=tr
     Expr(result)
 end
 
-if ccall(:jl_generating_output, Cint, ()) == 0
-    REDIRECTED_STDERR = STDERR
-    redirect_stderr(ORIG_STDERR)
-end
 =#
 

--- a/src/hooks.jl
+++ b/src/hooks.jl
@@ -1,6 +1,160 @@
-module BaseHooks
-
 using CSTParser
+using CSTParser: typof, EXPR
+
+# Find first parser error. All other errors are ignored.
+function first_error(ex::EXPR)
+    _first_error(ex, Tuple{EXPR,Int}[], 0)
+end
+
+function _first_error(ex, trace, pos)
+    push!(trace, (ex,pos))
+    if typof(ex) === CSTParser.ErrorToken
+        return trace
+    end
+    for i in 1:length(ex)
+        res = _first_error(ex[i], trace, pos)
+        if !isnothing(res)
+            return res
+        end
+        pos += ex[i].fullspan
+    end
+    pop!(trace)
+    return nothing
+end
+
+function cst_parse(src::SourceFile, rule)
+    buf = IOBuffer(src.data)
+    ps = CSTParser.ParseState(buf)
+    cont = rule == 2 ? false : true
+    cst,_ = CSTParser.parse(ps, cont)
+    err_trace = first_error(cst)
+    if !isnothing(err_trace)
+        report_error(stderr, src, err_trace)
+    end
+    cst
+end
+
+function make_underline(width,
+                        #chars=('^','~','^','|')
+                        chars=('▔','▔','▔','▎')
+                        #chars=('┗','━','┛','▎')
+                       )
+    if width == 0
+        chars[4]
+    elseif width <= 2
+        chars[2]^width
+    else
+        string(chars[1], chars[2]^(width-2), chars[3])
+    end
+end
+
+function explain_error(err_trace)
+    ex,_ = err_trace[end]
+    # FIXME: Framework for explaining parse errors
+    errcode = CSTParser.errorof(ex)
+    if errcode == CSTParser.UnexpectedToken
+        "Unexpected token"
+    elseif errcode == CSTParser.CannotJuxtapose
+        "Cannot juxtapose"
+    elseif errcode == CSTParser.UnexpectedWhiteSpace
+        "Unexpected white space"
+    elseif errcode == CSTParser.UnexpectedNewLine
+        "Unexpected newline"
+    elseif errcode == CSTParser.ExpectedAssignment
+        "Expected assignment"
+    elseif errcode == CSTParser.UnexpectedAssignmentOp
+        "Unexpected assignment"
+    elseif errcode == CSTParser.MissingConditional
+        "Missing conditional"
+    elseif errcode == CSTParser.MissingCloser
+        "Missing closer"
+    elseif errcode == CSTParser.InvalidIterator
+        "Invalid iterator"
+    elseif errcode == CSTParser.StringInterpolationWithTrailingWhitespace
+        "'\$' cannot be followed by whitespace in string interpolation"
+    elseif errcode == CSTParser.TooLongChar
+        "Character too long"
+    elseif errcode == CSTParser.Unknown
+        "Unknown error!"
+    else
+        "Unknown error code ($errcode)"
+    end
+end
+
+function report_error(io, src, err_trace; ctxlines=3)
+    indexed = IndexedSource(src)
+    ex,offset = err_trace[end]
+    line,col = source_location(indexed, offset)
+    for ln = max(1,line-ctxlines):max(0,line-1)
+        println(io, rstrip(indexed[ln]))
+    end
+    endline,endcol = source_location(indexed, offset + ex.span)
+    endcol2 = endline == line ? endcol : textwidth(indexed[line])
+    println(io, rstrip(indexed[line]))
+    print(io, ' '^(col-1))
+    printstyled(io, make_underline(endcol2-col+1); color=:green, bold = true)
+    println(io)
+    printstyled(io, "ERROR"; color=:red)
+    println(io, " at $(src.filename):$line:$col")
+    println(io, explain_error(err_trace))
+    println(io)
+    e2 = deepcopy(ex)
+    e2.parent=nothing
+    dump(e2)
+end
+
+# jl_parse implementation using CSTParser
+function julia_jl_parse(text, text_len, filename, filename_len, pos0, rule)
+    if rule == 1
+        error("TODO")
+    elseif rule != 2 && rule != 3
+        error("Unknown parser rule: $rule")
+    end
+    if pos0 != 0
+        error("TODO")
+    end
+    src = SourceFile(unsafe_wrap(Array, text, text_len),
+                     filename=unsafe_string(filename, filename_len))
+    cst = cst_parse(src, rule)
+    ex = Expr(cst)
+    if ex isa Expr && ex.head == :file
+        ex = Expr(:toplevel, ex.args...)
+    end
+    return Core.svec(ex, text_len)
+end
+
+# Extra shim for sanity during development
+function _julia_jl_parse(text, text_len, filename, filename_len, pos0, rule)
+    try
+        res = Base.invokelatest(julia_jl_parse, text, text_len,
+                                filename, filename_len, pos0, rule)
+        return res
+    catch exc
+        @error "Calling CSTParser failed. Falling back to flisp parser" #=
+        =#     exception=exc,catch_backtrace()
+        return @ccall jl_fl_parse(text::Ptr{UInt8}, sizeof(text)::Csize_t,
+                                  filename::Ptr{UInt8}, sizeof(filename)::Csize_t,
+                                  pos0::Csize_t, rule::Cint)::Any
+    end
+end
+
+function set_parser!()
+    parser = @cfunction(_julia_jl_parse, Any,
+                        (Ptr{UInt8}, Csize_t, Ptr{UInt8}, Csize_t, Csize_t, Cint))
+    @ccall jl_set_parser(parser::Ptr{Cvoid})::Cvoid
+end
+
+# Hack: quick test tool
+function test_jl_parse(text, filename, pos, rule)
+    pos0 = pos-1
+    parser = @eval @cfunction(_julia_jl_parse, Any,
+                        (Ptr{UInt8}, Csize_t, Ptr{UInt8}, Csize_t, Csize_t, Cint))
+    @ccall $parser(text::Ptr{UInt8}, sizeof(text)::Csize_t,
+                   filename::Ptr{UInt8}, sizeof(filename)::Csize_t,
+                   pos0::Csize_t, rule::Cint)::Any
+end
+
+#=
 using FancyDiagnostics: display_diagnostic
 using Base: Meta
 
@@ -92,5 +246,5 @@ if ccall(:jl_generating_output, Cint, ()) == 0
     REDIRECTED_STDERR = STDERR
     redirect_stderr(ORIG_STDERR)
 end
+=#
 
-end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,2 +1,7 @@
 using FancyDiagnostics
 using Base.Test
+
+src = raw"""
+end
+
+"""


### PR DESCRIPTION
These changes allow CSTParser to be connected up as the main Julia parser.

To use it, you currently need both a branch of the Julia runtime and of CSTParser:
* https://github.com/JuliaLang/julia/pull/35243
* https://github.com/c42f/CSTParser.jl/tree/cjf/Expr-linenumbers

Then run `FancyDiagnostics.enable!()`, and we can have errors such as:

[![asciicast](https://asciinema.org/a/326675.svg)](https://asciinema.org/a/326675)


### Dev notes

Early screenshot:

![sshot_1](https://user-images.githubusercontent.com/601473/79818976-5fad9580-83cc-11ea-8cf2-ce55d0b22d61.png)

Note that the current implementation is pretty rough and diagnostic printing will still crash at the drop of a hat (I still need to understand how CSTParser uses ErrorToken a lot better and figure how to cleanly deal with offsets at EOF which are very common)

TODO:
* [ ] Better understand how ErrorToken is used to encode the span, and what the deal is with nested error tokens.
* [x] Make handling errors at EOF actually work
* [ ] Detect incomplete expressions and return `Expr(:incomplete)`
* [ ] Much better error messages. The above example is not really representative in that CSTParser has only a handful of very generic error states. (Perhaps the CST itself will provide the context for more useful messages, or perhaps we'll need to put messages back into CSTParser itself.)